### PR TITLE
BUGFIX: Enable the group list path as well

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -38,6 +38,7 @@ func Backend(c *logical.BackendConfig) *backend {
 				pathConfigLdap(b),
 				pathLogin(b),
 				pathGroups(b),
+				pathGroupsList(b),
 			},
 		),
 	}


### PR DESCRIPTION
The group listing path is configured in the plugin,
just like in Vault's built-in LDAP backend,
but it is not enabled as one of the plugin's supported paths.

Let's enable it to make listing of groups available as well.