### PR TITLE
Fix login test

### DIFF
--- a/path_login_test.go
+++ b/path_login_test.go
@@ -50,7 +50,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	resp, err := b.HandleRequest(context.Background(), ldapReq)
-	if err != nil || (resp == nil && resp.IsError()) {
+	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err: %s resp: %#v\n", err, resp)
 	}
 

--- a/path_login_test.go
+++ b/path_login_test.go
@@ -2,10 +2,13 @@ package kerberos
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/logical"
+	"github.com/ory/dockertest"
+	"gopkg.in/ldap.v3"
 )
 
 func setupTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
@@ -34,6 +37,23 @@ func setupTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
 func TestLogin(t *testing.T) {
 	b, storage := setupTestBackend(t)
 
+	cleanup, connURL := prepareLDAPTestContainer(t)
+	defer cleanup()
+
+	ldapReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/ldap",
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"url": connURL,
+		},
+	}
+
+	resp, err := b.HandleRequest(context.Background(), ldapReq)
+	if err != nil || (resp == nil && resp.IsError()) {
+		t.Fatalf("err: %s resp: %#v\n", err, resp)
+	}
+
 	data := map[string]interface{}{
 		"authorization": "",
 	}
@@ -45,11 +65,70 @@ func TestLogin(t *testing.T) {
 		Data:      data,
 	}
 
-	resp, err := b.HandleRequest(context.Background(), req)
+	resp, err = b.HandleRequest(context.Background(), req)
 	if err != nil || resp == nil {
 		t.Fatalf("err: %s resp: %#v\n", err, resp)
 	}
 	if !resp.IsError() && !strings.HasPrefix(resp.Error().Error(), "Missing or invalid authorization") {
 		t.Fatalf("err: %s resp: %#v\n", err, resp)
 	}
+}
+
+func prepareLDAPTestContainer(t *testing.T) (cleanup func(), retURL string) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Failed to connect to docker: %s", err)
+	}
+
+	runOpts := &dockertest.RunOptions{
+		Repository: "osixia/openldap",
+		Tag:        "latest",
+		Env:        []string{"LDAP_TLS=false"},
+	}
+	resource, err := pool.RunWithOptions(runOpts)
+	if err != nil {
+		t.Fatalf("Could not start local MSSQL docker container: %s", err)
+	}
+
+	cleanup = func() {
+		if err := pool.Purge(resource); err != nil {
+			t.Fatalf("Failed to cleanup local container: %s", err)
+		}
+	}
+
+	ldapAddr := fmt.Sprintf("localhost:%s", resource.GetPort("389/tcp"))
+	retURL = "ldap://" + ldapAddr
+
+	// exponential backoff-retry
+	if err = pool.Retry(func() error {
+		conn, err := ldap.Dial("tcp", ldapAddr)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		if err := conn.Bind("cn=admin,dc=example,dc=org", "admin"); err != nil {
+			return err
+		}
+
+		searchRequest := ldap.NewSearchRequest(
+			"dc=example,dc=org",
+			ldap.ScopeWholeSubtree,
+			ldap.NeverDerefAliases,
+			0,
+			0,
+			false,
+			"(&(objectClass=*))",
+			[]string{"dn", "cn"},
+			nil,
+		)
+		if _, err := conn.Search(searchRequest); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Could not connect to ldap auth docker container: %s", err)
+	}
+
+	return
 }


### PR DESCRIPTION
Currently, the login test fails for me locally like this:
```
--- FAIL: TestLogin (0.00s)
    path_login_test.go:50: err: Could not connect to LDAP: 1 error occurred:
        
        * error connecting to host "ldap://127.0.0.1": LDAP Result Code 200 "Network Error": dial tcp 127.0.0.1:389: connect: connection refused resp: (*logical.Response)(nil)
FAIL
exit status 1
FAIL	github.com/tyrannosaurus-becks/vault-plugin-auth-kerberos	0.004s
```
This PR fixes that test by spinning up a local LDAP instance in Docker and using it for the test. This could be useful for further quick and easy dev.